### PR TITLE
Add `service.name` Attribute to Metrics

### DIFF
--- a/nrcensus/exporter.go
+++ b/nrcensus/exporter.go
@@ -162,12 +162,13 @@ func (e *Exporter) ExportView(vd *view.Data) {
 		return
 	}
 	for _, row := range vd.Rows {
-		attrs := make(map[string]interface{}, len(row.Tags)+2)
+		attrs := make(map[string]interface{}, len(row.Tags)+3)
 		for _, tag := range row.Tags {
 			attrs[tag.Key.Name()] = tag.Value
 		}
 		attrs["measure.name"] = vd.View.Measure.Name()
 		attrs["measure.unit"] = vd.View.Measure.Unit()
+		attrs["service.name"] = e.ServiceName
 
 		switch data := row.Data.(type) {
 		case *view.CountData:

--- a/nrcensus/exporter_metric_test.go
+++ b/nrcensus/exporter_metric_test.go
@@ -165,6 +165,7 @@ func TestCountMetrics(t *testing.T) {
 			"second":       "secondValue",
 			"measure.name": "tests",
 			"measure.unit": "t",
+			"service.name": "serviceName",
 		},
 	}) {
 		t.Errorf("metric fields are incorrect: %#v", metric)
@@ -174,7 +175,7 @@ func TestCountMetrics(t *testing.T) {
 		Value:          0,
 		Timestamp:      testTime.Add(10 * time.Second),
 		Interval:       10 * time.Second,
-		AttributesJSON: json.RawMessage(`{"first":"firstValue","measure.name":"tests","measure.unit":"t","second":"secondValue"}`),
+		AttributesJSON: json.RawMessage(`{"first":"firstValue","measure.name":"tests","measure.unit":"t","second":"secondValue","service.name":"serviceName"}`),
 	}) {
 		t.Errorf("metric fields are incorrect: %#v", metric)
 	}
@@ -183,7 +184,7 @@ func TestCountMetrics(t *testing.T) {
 		Value:          5,
 		Timestamp:      testTime.Add(20 * time.Second),
 		Interval:       10 * time.Second,
-		AttributesJSON: json.RawMessage(`{"first":"firstValue","measure.name":"tests","measure.unit":"t","second":"secondValue"}`),
+		AttributesJSON: json.RawMessage(`{"first":"firstValue","measure.name":"tests","measure.unit":"t","second":"secondValue","service.name":"serviceName"}`),
 	}) {
 		t.Errorf("metric fields are incorrect: %#v", metric)
 	}
@@ -235,6 +236,7 @@ func TestSumMetrics(t *testing.T) {
 			"second":       "secondValue",
 			"measure.name": "tests",
 			"measure.unit": "t",
+			"service.name": "serviceName",
 		},
 	}) {
 		t.Errorf("metric fields are incorrect: %#v", metric)
@@ -244,7 +246,7 @@ func TestSumMetrics(t *testing.T) {
 		Value:          0,
 		Timestamp:      testTime.Add(10 * time.Second),
 		Interval:       10 * time.Second,
-		AttributesJSON: json.RawMessage(`{"first":"firstValue","measure.name":"tests","measure.unit":"t","second":"secondValue"}`),
+		AttributesJSON: json.RawMessage(`{"first":"firstValue","measure.name":"tests","measure.unit":"t","second":"secondValue","service.name":"serviceName"}`),
 	}) {
 		t.Errorf("metric fields are incorrect: %#v", metric)
 	}
@@ -253,7 +255,7 @@ func TestSumMetrics(t *testing.T) {
 		Value:          5,
 		Timestamp:      testTime.Add(20 * time.Second),
 		Interval:       10 * time.Second,
-		AttributesJSON: json.RawMessage(`{"first":"firstValue","measure.name":"tests","measure.unit":"t","second":"secondValue"}`),
+		AttributesJSON: json.RawMessage(`{"first":"firstValue","measure.name":"tests","measure.unit":"t","second":"secondValue","service.name":"serviceName"}`),
 	}) {
 		t.Errorf("metric fields are incorrect: %#v", metric)
 	}
@@ -304,6 +306,7 @@ func TestLastValueMetrics(t *testing.T) {
 			"second":       "secondValue",
 			"measure.name": "tests",
 			"measure.unit": "t",
+			"service.name": "serviceName",
 		},
 	}) {
 		t.Errorf("metric fields are incorrect: %#v", metric)
@@ -317,6 +320,7 @@ func TestLastValueMetrics(t *testing.T) {
 			"second":       "secondValue",
 			"measure.name": "tests",
 			"measure.unit": "t",
+			"service.name": "serviceName",
 		},
 	}) {
 		t.Errorf("metric fields are incorrect: %#v", metric)
@@ -330,6 +334,7 @@ func TestLastValueMetrics(t *testing.T) {
 			"second":       "secondValue",
 			"measure.name": "tests",
 			"measure.unit": "t",
+			"service.name": "serviceName",
 		},
 	}) {
 		t.Errorf("metric fields are incorrect: %#v", metric)


### PR DESCRIPTION
Update the `ExportView` function to annotate the New Relic metrics it creates with a `service.name` attribute. This will allow New Relic to annotate the metrics with to an entity.

Resolves #5