### PR TITLE
Release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] 2020-02-12
+### Added
+- Set the `instrumentation.provider` attribute for all spans and metrics exported.
+- Set the `collector.name` attribute for all spans and metrics exported.
+
 ## [0.3.0] 2020-01-17
 ### Added
 - Include `service.name` attributes to all metrics.

--- a/nrcensus/version.go
+++ b/nrcensus/version.go
@@ -1,7 +1,7 @@
 package nrcensus
 
 const (
-	version                 = "0.3.0"
+	version                 = "0.4.0"
 	userAgentProduct        = "NewRelic-OpenCensus-Exporter"
 	collectorName           = "newrelic-opencensus-go-exporter"
 	instrumentationProvider = "opencensus"


### PR DESCRIPTION
### Added

- Set the `instrumentation.provider` attribute for all spans and metrics exported.
- Set the `collector.name` attribute for all spans and metrics exported.