### PR TITLE
remove duplicated 'Find and use your data' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,19 +48,7 @@ Tips on how to find and query your data:
 For general querying information, see:
 - [Query New Relic data](https://docs.newrelic.com/docs/using-new-relic/data/understand-data/query-new-relic-data)
 - [Intro to NRQL](https://docs.newrelic.com/docs/query-data/nrql-new-relic-query-language/getting-started/introduction-nrql)
-
-
-## Find and use your data
-
-Tips on how to find and query your data:
-
-- [Find metric data](https://docs.newrelic.com/docs/data-ingest-apis/get-data-new-relic/metric-api/introduction-metric-api#find-data)
-- [Find trace/span data](https://docs.newrelic.com/docs/understand-dependencies/distributed-tracing/trace-api/introduction-trace-api#view-data)
-
-For general querying information, see:
-
-- [Query New Relic data](https://docs.newrelic.com/docs/using-new-relic/data/understand-data/query-new-relic-data)
-- [Intro to NRQL](https://docs.newrelic.com/docs/query-data/nrql-new-relic-query-language/getting-started/nrql-syntax-clauses-functions)
+- [NRQL syntax, clauses, and functions](https://docs.newrelic.com/docs/query-data/nrql-new-relic-query-language/getting-started/nrql-syntax-clauses-functions)
 
 
 ## Licensing


### PR DESCRIPTION
The README 'Find and use your data' section was duplicated, with one unique link. I added that link into the first section and removed the duplicate section.